### PR TITLE
Logging Abstraction Layer

### DIFF
--- a/StackExchange.NetGain.Console/Program.cs
+++ b/StackExchange.NetGain.Console/Program.cs
@@ -11,6 +11,7 @@ using StackExchange.NetGain;
 using StackExchange.NetGain.WebSockets;
 using TcpClient = StackExchange.NetGain.TcpClient;
 using System.Text.RegularExpressions;
+using StackExchange.NetGain.Logging;
 
 namespace ConsoleApplication1
 {
@@ -19,6 +20,9 @@ namespace ConsoleApplication1
         
         static void Main()
         {
+            // Overriding default NoOpLogManager to log to Console instead
+            LogManager.Current = new ConsoleLogManager();
+
             IPEndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 6002);
             using(var server = new TcpServer())
             {

--- a/StackExchange.NetGain/CircularBuffer.cs
+++ b/StackExchange.NetGain/CircularBuffer.cs
@@ -2,13 +2,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
-using System.Diagnostics;
+using StackExchange.NetGain.Logging;
 
 namespace StackExchange.NetGain
 {
     internal class ConnectionSet : IEnumerable<Connection>
     {
         private Connection[] connections = new Connection[10];
+        private readonly ILog log = LogManager.Current.GetLogger<ConnectionSet>();
 
         private int count;
         public int Count
@@ -32,7 +33,7 @@ namespace StackExchange.NetGain
                 Array.Resize(ref connections, oldLen * 2);
                 connections[oldLen] = connection;
 #if VERBOSE
-                Debug.WriteLine(string.Format("resized ConnectionSet: {0}", connections.Length));
+                log.Debug("resized ConnectionSet: {0}", connections.Length);
 #endif
             }
         }

--- a/StackExchange.NetGain/Connection.cs
+++ b/StackExchange.NetGain/Connection.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.IO;
+using StackExchange.NetGain.Logging;
 
 namespace StackExchange.NetGain
 {
@@ -12,6 +12,7 @@ namespace StackExchange.NetGain
     {
         public object UserToken { get; set; }
 
+        private readonly ILog log;
         private IProtocolProcessor protocol;
         public Socket Socket { get; set; }
         public virtual void Reset()
@@ -23,6 +24,7 @@ namespace StackExchange.NetGain
         }
         public Connection()
         {
+            log = LogManager.Current.GetLogger<Connection>();
             Reset();
         }
         public void SetProtocol(IProtocolProcessor protocol)
@@ -203,7 +205,7 @@ namespace StackExchange.NetGain
                     if (!CanRead) break; // stop processing data
 #if VERBOSE
                     long inboundLength = incomingBuffer.Length;
-                    Debug.WriteLine(string.Format("[{0}]\tprocessing with {1} bytes available", context.Handler, inboundLength));
+                    log.Debug("[{0}]\tprocessing with {1} bytes available", context.Handler, inboundLength);
 #endif
                     incomingBuffer.Position = 0;
                     toDiscard = protocol.ProcessIncoming(context, this, incomingBuffer);
@@ -224,7 +226,7 @@ namespace StackExchange.NetGain
                             
                         } 
 #if VERBOSE
-                        Debug.WriteLine(string.Format("[{0}]\tprocessed {1} bytes; {2} remaining", context.Handler, toDiscard, inboundLength - toDiscard));
+                        log.Debug("[{0}]\tprocessed {1} bytes; {2} remaining", context.Handler, toDiscard, inboundLength - toDiscard);
 #endif
                     } else if(toDiscard < 0)
                     {
@@ -240,7 +242,7 @@ namespace StackExchange.NetGain
                     else
                     {
 #if VERBOSE
-                        Debug.WriteLine(string.Format("[{0}]\tincomplete", context.Handler));
+                        log.Debug("[{0}]\tincomplete", context.Handler);
 #endif
                     }
                 } while (toDiscard > 0 && incomingBuffer != null && incomingBuffer.Length > 0);

--- a/StackExchange.NetGain/Logging/ConsoleLogManager.cs
+++ b/StackExchange.NetGain/Logging/ConsoleLogManager.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace StackExchange.NetGain.Logging
+{
+    public class ConsoleLogManager : LogManager
+    {
+        private static readonly Lazy<ConsoleLogger> Log = new Lazy<ConsoleLogger>(() => new ConsoleLogger()); 
+        public override ILog GetLogger<T>()
+        {
+            return Log.Value;
+        }
+
+        public override ILog GetLogger(string logName)
+        {
+            return Log.Value;
+        }
+    }
+}

--- a/StackExchange.NetGain/Logging/ConsoleLogger.cs
+++ b/StackExchange.NetGain/Logging/ConsoleLogger.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace StackExchange.NetGain.Logging
+{
+    public class ConsoleLogger : ILog
+    {
+        public void Error(string value)
+        {
+             Console.Error.WriteLine(value);
+        }
+
+        public void Error(string format, params object[] arg)
+        {
+            Console.Error.WriteLine(format, arg);
+        }
+
+        public void Info(string value)
+        {
+            Console.WriteLine(value);
+        }
+
+        public void Info(string format, params object[] arg)
+        {
+            Console.WriteLine(format, arg);
+        }
+
+        public void Debug(string value)
+        {
+            System.Diagnostics.Debug.WriteLine(value);
+        }
+
+        public void Debug(string format, params object[] arg)
+        {
+            System.Diagnostics.Debug.WriteLine(format, arg);
+        }
+    }
+}

--- a/StackExchange.NetGain/Logging/ILog.cs
+++ b/StackExchange.NetGain/Logging/ILog.cs
@@ -1,0 +1,17 @@
+﻿namespace StackExchange.NetGain.Logging
+{
+    public interface ILog
+    {
+        void Error(string value);
+
+        void Error(string format, params object[] arg);
+
+        void Info(string value);
+
+        void Info(string format, params object[] arg);
+
+        void Debug(string value);
+
+        void Debug(string format, params object[] arg);
+    }
+}

--- a/StackExchange.NetGain/Logging/LogManager.cs
+++ b/StackExchange.NetGain/Logging/LogManager.cs
@@ -1,0 +1,16 @@
+﻿namespace StackExchange.NetGain.Logging
+{
+    public abstract class LogManager
+    {
+        public static LogManager Current { get; set; }
+
+        static LogManager()
+        {
+            Current = new NoOpLogManager();
+        }
+
+        public abstract ILog GetLogger<T>();
+
+        public abstract ILog GetLogger(string logName);
+    }
+}

--- a/StackExchange.NetGain/Logging/NoOpLogManager.cs
+++ b/StackExchange.NetGain/Logging/NoOpLogManager.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace StackExchange.NetGain.Logging
+{
+    public class NoOpLogManager : LogManager
+    {
+        private static readonly Lazy<ILog> Log = new Lazy<ILog>(() => new NoOpLogger()); 
+
+        public override ILog GetLogger<T>()
+        {
+            return Log.Value;
+        }
+
+        public override ILog GetLogger(string logName)
+        {
+            return Log.Value;
+        }
+    }
+}

--- a/StackExchange.NetGain/Logging/NoOpLogger.cs
+++ b/StackExchange.NetGain/Logging/NoOpLogger.cs
@@ -1,0 +1,16 @@
+﻿namespace StackExchange.NetGain.Logging
+{
+    public class NoOpLogger : ILog {
+        public void Error(string value) { }
+
+        public void Error(string format, params object[] arg) { }
+
+        public void Info(string value) { }
+
+        public void Info(string format, params object[] arg) { }
+
+        public void Debug(string value) { }
+
+        public void Debug(string format, params object[] arg) { }
+    }
+}

--- a/StackExchange.NetGain/StackExchange.NetGain.csproj
+++ b/StackExchange.NetGain/StackExchange.NetGain.csproj
@@ -83,6 +83,12 @@
     <Compile Include="IMessageProcessor.cs" />
     <Compile Include="IProtocolFactory.cs" />
     <Compile Include="IProtocolProcessor.cs" />
+    <Compile Include="Logging\ConsoleLogger.cs" />
+    <Compile Include="Logging\ConsoleLogManager.cs" />
+    <Compile Include="Logging\ILog.cs" />
+    <Compile Include="Logging\LogManager.cs" />
+    <Compile Include="Logging\NoOpLogger.cs" />
+    <Compile Include="Logging\NoOpLogManager.cs" />
     <Compile Include="Message.cs" />
     <Compile Include="MessageProcessorServiceInstaller.cs">
       <SubType>Component</SubType>

--- a/StackExchange.NetGain/WebSockets/WebSocketsProcessor.cs
+++ b/StackExchange.NetGain/WebSockets/WebSocketsProcessor.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.IO;
 using System.Text;
+using StackExchange.NetGain.Logging;
 
 namespace StackExchange.NetGain.WebSockets
 {
     public abstract class WebSocketsProcessor : IProtocolProcessor
     {
+        private readonly ILog log = LogManager.Current.GetLogger<WebSocketsProcessor>();
 
         int IProtocolProcessor.ProcessIncoming(NetContext context, Connection connection,
                                                System.IO.Stream incomingBuffer)
@@ -44,7 +45,7 @@ namespace StackExchange.NetGain.WebSockets
                 if(result != null)
                 {
 #if VERBOSE
-                    Debug.WriteLine("popped (control): " + result);   
+                    log.Debug("popped (control): " + result);   
 #endif
                 }
                 else
@@ -53,7 +54,7 @@ namespace StackExchange.NetGain.WebSockets
                     if (result != null)
                     {
 #if VERBOSE
-                        Debug.WriteLine("popped (data): " + result);
+                        log.Debug("popped (data): " + result);
 #endif
                     }
                 }
@@ -67,7 +68,7 @@ namespace StackExchange.NetGain.WebSockets
             {
                 ProtocolProcessor.AddFrame(context, ref dataQueue, frame);
 #if VERBOSE
-                Debug.WriteLine("pushed (data): " + frame);
+                log.Debug("pushed (data): " + frame);
 #endif
             }
         }
@@ -79,7 +80,7 @@ namespace StackExchange.NetGain.WebSockets
                 {
                     ProtocolProcessor.AddFrame(context, ref dataQueue, frame);
 #if VERBOSE
-                    Debug.WriteLine("pushed (data): " + frame);
+                    log.Debug("pushed (data): " + frame);
 #endif
                 }
             }
@@ -94,7 +95,7 @@ namespace StackExchange.NetGain.WebSockets
             {
                 ProtocolProcessor.AddFrame(context, ref controlQueue, frame);
 #if VERBOSE
-                Debug.WriteLine("pushed (control): " + frame);
+                log.Debug("pushed (control): " + frame);
 #endif
             }
         }

--- a/StackExchange.NetGain/WebSockets/WebSocketsProcessor_RFC6455_13.cs
+++ b/StackExchange.NetGain/WebSockets/WebSocketsProcessor_RFC6455_13.cs
@@ -3,9 +3,9 @@ using System.IO;
 using System;
 using System.Security.Cryptography;
 using System.Text;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
+using StackExchange.NetGain.Logging;
 
 namespace StackExchange.NetGain.WebSockets
 {
@@ -15,9 +15,12 @@ namespace StackExchange.NetGain.WebSockets
         {
             return "rfc6455";
         }
+
+        private readonly ILog log;
         private readonly bool isClient;
         public WebSocketsProcessor_RFC6455_13(bool isClient)
         {
+            log = LogManager.Current.GetLogger<WebSocketsProcessor_RFC6455_13>();
             this.isClient = isClient;
         }
         public bool IsClient { get { return isClient; } }
@@ -113,7 +116,7 @@ namespace StackExchange.NetGain.WebSockets
                 int payloadLen = frame.PayloadLength;
 
 #if VERBOSE
-                Debug.WriteLine("Parsed header from: " + BitConverter.ToString(buffer, 0, headerLength));
+                log.Debug("Parsed header from: " + BitConverter.ToString(buffer, 0, headerLength));
 #endif
 
                 if (incoming.Length < headerLength + payloadLen) return 0; // not enough data to read the payload
@@ -247,7 +250,7 @@ namespace StackExchange.NetGain.WebSockets
             }
             if (frame.OpCode == WebSocketsFrame.OpCodes.Close)
             {
-                Debug.WriteLine("Sent close frame: " + connection);
+                log.Debug("Sent close frame: " + connection);
             }
         }
         private void Process(NetContext context, Connection connection, Stream stream, WebSocketsFrame.OpCodes opCode)
@@ -320,7 +323,7 @@ namespace StackExchange.NetGain.WebSockets
                 {
                     int charCount = Math.Min(remaining, wsConnection.MaxCharactersPerFrame);
                     var buffer = encoding.GetBytes(charBuffer, charIndex, charCount);
-                    //Debug.WriteLine("> " + new string(charBuffer, charIndex, charCount));
+                    //log.Debug("> " + new string(charBuffer, charIndex, charCount));
                     remaining -= charCount;
                     charIndex += charCount;
 
@@ -350,7 +353,7 @@ namespace StackExchange.NetGain.WebSockets
             {
                 frame.OpCode = WebSocketsFrame.OpCodes.Text;
                 var buffer = encoding.GetBytes(s);
-                //Debug.WriteLine("> " + s);
+                //log.Debug("> " + s);
                 frame.Payload.Write(buffer, 0, buffer.Length);
                 frame.PayloadLength = buffer.Length;
             }

--- a/StackExchange.NetGain/WebSockets/WebSocketsProcessor_RFC6455_13.cs
+++ b/StackExchange.NetGain/WebSockets/WebSocketsProcessor_RFC6455_13.cs
@@ -272,26 +272,18 @@ namespace StackExchange.NetGain.WebSockets
                     case WebSocketsFrame.OpCodes.Binary:
                         byte[] blob;
                         int len;
-                        if (stream == null || (len = ((int)stream.Length - (int)stream.Position)) == 0) blob = new byte[0]; 
+                        if (stream == null || (len = ((int)stream.Length)) == 0) blob = new byte[0]; 
                         else
                         {
                             blob = new byte[len];
-                            byte[] buffer = null;
-                            try
+                            int offset = 0, read;
+                            stream.Position = 0;
+                            while((read = stream.Read(blob, offset, len)) > 0)
                             {
-                                buffer = context.GetBuffer();
-                                int offset = 0, read;
-                                stream.Position = 0;
-                                while((read = stream.Read(buffer, offset, Math.Min(len, buffer.Length))) > 0)
-                                {
-                                    offset += read;
-                                    len -= read;
-                                }
-                                if(len != 0) throw new EndOfStreamException();
-                            } finally
-                            {
-                                context.Recycle(buffer);
+                                offset += read;
+                                len -= read;
                             }
+                            if(len != 0) throw new EndOfStreamException();
                         }
                         context.Handler.OnReceived(connection, blob);
                         break;

--- a/StackExchange.NetGain/WebSockets/WebSocketsSelectorProcessor.cs
+++ b/StackExchange.NetGain/WebSockets/WebSocketsSelectorProcessor.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Net;
 using System.Text;
+using StackExchange.NetGain.Logging;
 
 namespace StackExchange.NetGain.WebSockets
 {
@@ -13,6 +14,7 @@ namespace StackExchange.NetGain.WebSockets
         public static WebSocketsSelectorProcessor Default { get { return @default; } }
         IProtocolProcessor IProtocolFactory.GetProcessor() { return this; }
         Connection IProtocolFactory.CreateConnection(EndPoint endpoint) { return new WebSocketConnection(endpoint); }
+        private readonly ILog log = LogManager.Current.GetLogger<WebSocketsSelectorProcessor>();
 
         protected override void Send(NetContext context, Connection connection, object message)
         {
@@ -170,7 +172,7 @@ namespace StackExchange.NetGain.WebSockets
                         {
                             sb.AppendFormat("{0}:\t{1}", key, headers[key]).AppendLine();
                         }
-                        Console.Error.WriteLine(sb);
+                        log.Error(sb.ToString());
                     }
                     throw new InvalidOperationException("Request was not a web-socket upgrade request; connection: " + headers["Connection"] + ", upgrade: " + headers["Upgrade"]);
                 }


### PR DESCRIPTION
Addressing Issue #5 by adding an internal Logging layer.
This defaults to NoOp logging but has an implementation of a Console logger to maintain the existing console logging functionality.

Expected usage is for users to implement ILog and LogManager for their specific logging solution. The LogManager and ILog interfaces are intentionally kept small so there's little to implement.

LogManager.Current needs to be assigned before using any of the framework. See the test console for example usage setting the Console logger.
