### PR TITLE
Add WebSocket Client example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,32 +31,60 @@ using StackExchange.NetGain.WebSockets;
 
 namespace Example
 {
-  public class Program
-  {
-    public static void Main (string[] args)
-    {
-		IPEndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 6002);
-		using(var server = new TcpServer())
+	public class Program
+	{
+		public static void Main (string[] args)
 		{
-			server.ProtocolFactory = WebSocketsSelectorProcessor.Default;
-			server.ConnectionTimeoutSeconds = 60;
-			server.Received += msg =>
+			IPEndPoint endpoint = new IPEndPoint(IPAddress.Loopback, 6002);
+			using(var server = new TcpServer())
 			{
-				var conn = (WebSocketConnection)msg.Connection;
-				string reply = (string)msg.Value + " / " + conn.Host;
-				Console.WriteLine("[server] {0}", msg.Value);
-				msg.Connection.Send(msg.Context, reply);
-			};
-			server.Start("abc", endpoint);
-			Console.WriteLine("Server running");
+				server.ProtocolFactory = WebSocketsSelectorProcessor.Default;
+				server.ConnectionTimeoutSeconds = 60;
+				server.Received += msg =>
+				{
+					var conn = (WebSocketConnection)msg.Connection;
+					string reply = (string)msg.Value + " / " + conn.Host;
+					Console.WriteLine("[server] {0}", msg.Value);
+					conn.Send(msg.Context, reply);
+				};
 
+				server.Start("abc", endpoint);
+
+				Console.WriteLine("Server running");
+				Console.ReadKey();
+			}
+
+			Console.WriteLine("Server dead; press any key");
 			Console.ReadKey();
 		}
-		Console.WriteLine("Server dead; press any key");
-		Console.ReadKey();
-      }
-    }
-  }
+	}
 }
 ```
 
+### WebSocket Client Example ###
+
+```csharp
+using System;
+using System.Net;
+using StackExchange.NetGain;
+using StackExchange.NetGain.WebSockets;
+
+namespace Example
+{
+	public class Program
+	{
+		public static void Main (string[] args)
+		{
+			using (var client = new TcpClient())
+			{
+				client.ProtocolFactory = WebSocketClientFactory.Default;
+				client.Open(new IPEndPoint(IPAddress.Loopback, 6002));
+
+				var message = Console.ReadLine();
+
+				string resp = (string)client.ExecuteSync(message);
+			}
+		}
+	}
+}
+```


### PR DESCRIPTION
I think it'd be helpful to provide a client code example to complement the server example in README.md. These two examples will successfully communicate over the given port 6002 if hosted in separate processes. I used two instances of LinqPad for testing.